### PR TITLE
Switch from m3db/stackmurmur3 to a customized implementation of murmur3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,8 @@ branches:
     - travis
 
 go:
-  - 1.8
-  - 1.9
+  - 1.13
+  - 1.14
   - tip
 
 matrix:

--- a/bloom.go
+++ b/bloom.go
@@ -43,7 +43,7 @@ var entropy = []byte{1}[:]
 
 func concurrentBloomFilterHashes(data []byte) [4]uint64 {
 	h1, h2 := murmur3.Sum128(data)
-	h3, h4 := murmur3.Sum128(entropy) // Add entropy
+	h3, h4 := murmur3.SeedSum128(h1, h2, entropy) // Add entropy
 	return [4]uint64{h1, h2, h3, h4}
 }
 

--- a/bloom_test.go
+++ b/bloom_test.go
@@ -64,10 +64,10 @@ func TestConcurrent(t *testing.T) {
 	wg.Wait()
 
 	if err1 != nil {
-		t.Error(err1)
+		t.Fatalf("bloom test 1 failed: %v", err1)
 	}
 	if err2 != nil {
-		t.Error(err2)
+		t.Fatalf("bloom test 2 failed: %v", err2)
 	}
 }
 

--- a/bloom_test.go
+++ b/bloom_test.go
@@ -220,7 +220,7 @@ func chiTestBloom(m, k, rounds uint, elements [][]byte) (succeeds bool) {
 	chi := make([]float64, m)
 
 	for _, data := range elements {
-		h := concurrentBloomFilterHashes(data)
+		h := sum128WithEntropy(data)
 		for i := uint64(0); i < f.k; i++ {
 			results[bloomFilterLocation(h, i, f.m)]++
 		}

--- a/bloom_test.go
+++ b/bloom_test.go
@@ -10,8 +10,6 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/spaolacci/murmur3"
-
 	"github.com/stretchr/testify/require"
 )
 
@@ -44,7 +42,7 @@ func TestConcurrent(t *testing.T) {
 		for i := 0; i < try; i++ {
 			n1b := ro.Test(n1)
 			if !n1b {
-				err1 = fmt.Errorf("%v should be in", n1)
+				err1 = fmt.Errorf("%v should be in", string(n1))
 				break
 			}
 		}
@@ -56,7 +54,7 @@ func TestConcurrent(t *testing.T) {
 		for i := 0; i < try; i++ {
 			n2b := ro.Test(n2)
 			if !n2b {
-				err2 = fmt.Errorf("%v should be in", n2)
+				err2 = fmt.Errorf("%v should be in", string(n2))
 				break
 			}
 		}
@@ -66,10 +64,10 @@ func TestConcurrent(t *testing.T) {
 	wg.Wait()
 
 	if err1 != nil {
-		t.Fatal(err1)
+		t.Error(err1)
 	}
 	if err2 != nil {
-		t.Fatal(err2)
+		t.Error(err2)
 	}
 }
 
@@ -221,10 +219,8 @@ func chiTestBloom(m, k, rounds uint, elements [][]byte) (succeeds bool) {
 	results := make([]uint, m)
 	chi := make([]float64, m)
 
-	hash := murmur3.New128()
 	for _, data := range elements {
-		hash.Reset()
-		h := bloomFilterHashes(hash, data)
+		h := concurrentBloomFilterHashes(data)
 		for i := uint64(0); i < f.k; i++ {
 			results[bloomFilterLocation(h, i, f.m)]++
 		}

--- a/glide.lock
+++ b/glide.lock
@@ -1,19 +1,20 @@
-hash: 92e25ff1ff7d4e7802b22bbef0dda7a873d90ef3823bef0e0ba859364cd63a88
-updated: 2020-08-27T14:37:28.119756-04:00
+hash: 2b9862f9963ea7bd113a42f2787b4921cc3646d9bf49bb58fd3c4c49c91714f0
+updated: 2020-08-27T21:13:59.818543-04:00
 imports:
 - name: github.com/m3db/bitset
   version: 07973db6b78acb62ac207d0538055e874b49d90d
-- name: github.com/m3db/stackmurmur3
-  version: 744c0229c12ed0e4f8cb9d081a2692b3300bf705
-- name: github.com/spaolacci/murmur3
-  version: 0d12bf811670bf6a1a63828dfbd003eded177fce
-- name: github.com/twmb/murmur3
-  version: a57a9e6e8d2a5858df4163dd85863a6a9d9c5474
 testImports:
 - name: github.com/davecgh/go-spew
   version: 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
   subpackages:
   - spew
+- name: github.com/leanovate/gopter
+  version: 8de0d746533ed4ca265750b9bcf3ba01839df390
+  subpackages:
+  - gen
+  - prop
+- name: github.com/m3db/stackmurmur3
+  version: 744c0229c12ed0e4f8cb9d081a2692b3300bf705
 - name: github.com/pmezard/go-difflib
   version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
   subpackages:
@@ -23,3 +24,5 @@ testImports:
   subpackages:
   - assert
   - require
+- name: github.com/twmb/murmur3
+  version: a57a9e6e8d2a5858df4163dd85863a6a9d9c5474

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 47580f63cd287ddc441046654c6cfb9f8ee3ae5ee1213646e73bc1ca17ded952
-updated: 2017-11-12T17:25:25.663662528-05:00
+hash: 92e25ff1ff7d4e7802b22bbef0dda7a873d90ef3823bef0e0ba859364cd63a88
+updated: 2020-08-27T14:37:28.119756-04:00
 imports:
 - name: github.com/m3db/bitset
   version: 07973db6b78acb62ac207d0538055e874b49d90d
@@ -7,6 +7,8 @@ imports:
   version: 744c0229c12ed0e4f8cb9d081a2692b3300bf705
 - name: github.com/spaolacci/murmur3
   version: 0d12bf811670bf6a1a63828dfbd003eded177fce
+- name: github.com/twmb/murmur3
+  version: a57a9e6e8d2a5858df4163dd85863a6a9d9c5474
 testImports:
 - name: github.com/davecgh/go-spew
   version: 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,10 +1,12 @@
 package: github.com/m3db/bloom
-import:
-- package: github.com/twmb/murmur3
-  version: ^1.1.4
+import: []
 testImport:
 - package: github.com/stretchr/testify
   version: 6fe211e493929a8aac0469b93f28b1d0688a9a3a
   subpackages:
   - assert
   - require
+- package: github.com/twmb/murmur3
+  version: ^1.1.4
+- package: github.com/leanovate/gopter
+  version: ^0.2.8

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,5 +1,7 @@
 package: github.com/m3db/bloom
-import: []
+import:
+- package: github.com/twmb/murmur3
+  version: ^1.1.4
 testImport:
 - package: github.com/stretchr/testify
   version: 6fe211e493929a8aac0469b93f28b1d0688a9a3a

--- a/murmur.go
+++ b/murmur.go
@@ -176,36 +176,50 @@ func sum128WithEntropy(data []byte) [4]uint64 {
 	switch rlen + 1 {
 	case 15:
 		k2 ^= entropy << 48
+		goto l14
 	case 14:
 		k2 ^= entropy << 40
+		goto l13
 	case 13:
 		k2 ^= entropy << 32
+		goto l12
 	case 12:
 		k2 ^= entropy << 24
+		goto l11
 	case 11:
 		k2 ^= entropy << 16
+		goto l10
 	case 10:
 		k2 ^= entropy << 8
+		goto l9
 	case 9:
 		k2 ^= entropy << 0
 		k2 *= c2_128
 		k2 = bits.RotateLeft64(k2, 33)
 		k2 *= c1_128
 		h2 ^= k2
+		goto l8
 	case 8:
 		k1 ^= entropy << 56
+		goto l7
 	case 7:
 		k1 ^= entropy << 48
+		goto l6
 	case 6:
 		k1 ^= entropy << 40
+		goto l5
 	case 5:
 		k1 ^= entropy << 32
+		goto l4
 	case 4:
 		k1 ^= entropy << 24
+		goto l3
 	case 3:
 		k1 ^= entropy << 16
+		goto l2
 	case 2:
 		k1 ^= entropy << 8
+		goto l1
 	case 1:
 		// Case where entropy byte is the actual tail (payload length is a multiple of 16 bytes)
 		k1 ^= entropy << 0
@@ -213,64 +227,45 @@ func sum128WithEntropy(data []byte) [4]uint64 {
 		k1 = bits.RotateLeft64(k1, 31)
 		k1 *= c2_128
 		h1 ^= k1
-		// Nothing else to do but finalize the hash
-		goto Finalize
+		goto Finalize // Nothing else to do but finalize the has
 	}
 
-	switch rlen {
-	case 14:
-		k2 ^= uint64(data[13]) << 40
-		fallthrough
-	case 13:
-		k2 ^= uint64(data[12]) << 32
-		fallthrough
-	case 12:
-		k2 ^= uint64(data[11]) << 24
-		fallthrough
-	case 11:
-		k2 ^= uint64(data[10]) << 16
-		fallthrough
-	case 10:
-		k2 ^= uint64(data[9]) << 8
-		fallthrough
-	case 9:
-		k2 ^= uint64(data[8]) << 0
-
-		k2 *= c2_128
-		k2 = bits.RotateLeft64(k2, 33)
-		k2 *= c1_128
-		h2 ^= k2
-
-		fallthrough
-
-	case 8:
-		k1 ^= uint64(data[7]) << 56
-		fallthrough
-	case 7:
-		k1 ^= uint64(data[6]) << 48
-		fallthrough
-	case 6:
-		k1 ^= uint64(data[5]) << 40
-		fallthrough
-	case 5:
-		k1 ^= uint64(data[4]) << 32
-		fallthrough
-	case 4:
-		k1 ^= uint64(data[3]) << 24
-		fallthrough
-	case 3:
-		k1 ^= uint64(data[2]) << 16
-		fallthrough
-	case 2:
-		k1 ^= uint64(data[1]) << 8
-		fallthrough
-	case 1:
-		k1 ^= uint64(data[0]) << 0
-		k1 *= c1_128
-		k1 = bits.RotateLeft64(k1, 31)
-		k1 *= c2_128
-		h1 ^= k1
-	}
+l14:
+	k2 ^= uint64(data[13]) << 40
+l13:
+	k2 ^= uint64(data[12]) << 32
+l12:
+	k2 ^= uint64(data[11]) << 24
+l11:
+	k2 ^= uint64(data[10]) << 16
+l10:
+	k2 ^= uint64(data[9]) << 8
+l9:
+	k2 ^= uint64(data[8]) << 0
+	k2 *= c2_128
+	k2 = bits.RotateLeft64(k2, 33)
+	k2 *= c1_128
+	h2 ^= k2
+l8:
+	k1 ^= uint64(data[7]) << 56
+l7:
+	k1 ^= uint64(data[6]) << 48
+l6:
+	k1 ^= uint64(data[5]) << 40
+l5:
+	k1 ^= uint64(data[4]) << 32
+l4:
+	k1 ^= uint64(data[3]) << 24
+l3:
+	k1 ^= uint64(data[2]) << 16
+l2:
+	k1 ^= uint64(data[1]) << 8
+l1:
+	k1 ^= uint64(data[0]) << 0
+	k1 *= c1_128
+	k1 = bits.RotateLeft64(k1, 31)
+	k1 *= c2_128
+	h1 ^= k1
 
 Finalize:
 	h1 ^= uint64(clen)

--- a/murmur.go
+++ b/murmur.go
@@ -132,7 +132,7 @@ func sum128WithEntropy(data []byte) [4]uint64 {
 	res[0], res[1] = h1, h2
 
 	// Now, reset state back to before the tail calculation.
-	// The state is such that all but up to final 15 bytes have been processed, as murmur3 works
+	// The state is such that all but final 15 bytes have been processed, as murmur3 works
 	// on 128 bit / 16 byte chunks for all but the final mixing.
 	// last byte of the array, and apply the Sum128() logic accordingly.
 	k1, k2 = 0, 0
@@ -172,10 +172,10 @@ func sum128WithEntropy(data []byte) [4]uint64 {
 
 	// Process entropy byte - note, **no fallthrough**, because how we process it depends on how long the payload is
 	switch rlen + 1 {
-	case 15:
+	case 15: // the entropy byte index is 15
 		k2 ^= entropy << 48
-		goto l14
-	case 14:
+		goto l14 // jump into processing rest of the array, at position 14
+	case 14: // entropy byte index is 14 ...
 		k2 ^= entropy << 40
 		goto l13
 	case 13:
@@ -228,9 +228,9 @@ func sum128WithEntropy(data []byte) [4]uint64 {
 		goto Finalize // Nothing else to do but finalize the hash
 	}
 
-	// Process the rest of the remainder.
-	// Entropy handling siwtch above will directly jump into the code below, depending on remaining
-	// payload length.
+	// Process the payload that is before entropy byte.
+	// Entropy was handled in the switch above: it will directly jump into the code below,
+	// depending on remaining payload length.
 l14:
 	k2 ^= uint64(data[13]) << 40
 l13:

--- a/murmur.go
+++ b/murmur.go
@@ -1,0 +1,272 @@
+package bloom
+
+import "math/bits"
+
+const (
+	c1_128         = 0x87c37b91114253d5
+	c2_128         = 0x4cf5ad432745937f
+	entropy uint64 = 1
+)
+
+// murmur3 hash variant from https://github.com/twmb/murmur3
+// used in M3DB bloom filter, code equivalent to:
+//
+// 	var hash stackmurmur3.Digest128
+// 	hash = hash.Write(data)
+// 	h1, h2 := hash.Sum128()
+// 	hash = hash.Write(entropy) // Add entropy
+// 	h3, h4 := hash.Sum128()
+// 	return [4]uint64{h1, h2, h3, h4}
+//
+// M3DB should really just use two different hashes
+func sum128WithEntropy(data []byte) [4]uint64 {
+	var (
+		h1, h2 uint64
+		res    [4]uint64
+	)
+	clen := len(data)
+	for len(data) >= 16 {
+		// yes, this is faster than using binary.LittleEndian.Uint64
+		k1 := uint64(data[0]) | uint64(data[1])<<8 | uint64(data[2])<<16 | uint64(data[3])<<24 | uint64(data[4])<<32 | uint64(data[5])<<40 | uint64(data[6])<<48 | uint64(data[7])<<56
+		k2 := uint64(data[8]) | uint64(data[9])<<8 | uint64(data[10])<<16 | uint64(data[11])<<24 | uint64(data[12])<<32 | uint64(data[13])<<40 | uint64(data[14])<<48 | uint64(data[15])<<56
+
+		data = data[16:]
+
+		k1 *= c1_128
+		k1 = bits.RotateLeft64(k1, 31)
+		k1 *= c2_128
+		h1 ^= k1
+
+		h1 = bits.RotateLeft64(h1, 27)
+		h1 += h2
+		h1 = h1*5 + 0x52dce729
+
+		k2 *= c2_128
+		k2 = bits.RotateLeft64(k2, 33)
+		k2 *= c1_128
+		h2 ^= k2
+
+		h2 = bits.RotateLeft64(h2, 31)
+		h2 += h1
+		h2 = h2*5 + 0x38495ab5
+	}
+
+	var _h1, _h2 = h1, h2 // save state after mixing, before final processing
+	var k1, k2 uint64
+	switch len(data) {
+	case 15:
+		k2 ^= uint64(data[14]) << 48
+		fallthrough
+	case 14:
+		k2 ^= uint64(data[13]) << 40
+		fallthrough
+	case 13:
+		k2 ^= uint64(data[12]) << 32
+		fallthrough
+	case 12:
+		k2 ^= uint64(data[11]) << 24
+		fallthrough
+	case 11:
+		k2 ^= uint64(data[10]) << 16
+		fallthrough
+	case 10:
+		k2 ^= uint64(data[9]) << 8
+		fallthrough
+	case 9:
+		k2 ^= uint64(data[8]) << 0
+
+		k2 *= c2_128
+		k2 = bits.RotateLeft64(k2, 33)
+		k2 *= c1_128
+		h2 ^= k2
+
+		fallthrough
+
+	case 8:
+		k1 ^= uint64(data[7]) << 56
+		fallthrough
+	case 7:
+		k1 ^= uint64(data[6]) << 48
+		fallthrough
+	case 6:
+		k1 ^= uint64(data[5]) << 40
+		fallthrough
+	case 5:
+		k1 ^= uint64(data[4]) << 32
+		fallthrough
+	case 4:
+		k1 ^= uint64(data[3]) << 24
+		fallthrough
+	case 3:
+		k1 ^= uint64(data[2]) << 16
+		fallthrough
+	case 2:
+		k1 ^= uint64(data[1]) << 8
+		fallthrough
+	case 1:
+		k1 ^= uint64(data[0]) << 0
+		k1 *= c1_128
+		k1 = bits.RotateLeft64(k1, 31)
+		k1 *= c2_128
+		h1 ^= k1
+	}
+
+	h1 ^= uint64(clen)
+	h2 ^= uint64(clen)
+
+	h1 += h2
+	h2 += h1
+
+	h1 = fmix64(h1)
+	h2 = fmix64(h2)
+
+	h1 += h2
+	h2 += h1
+
+	res[0], res[1] = h1, h2 // done with 1st hash
+	// the last 128 bytes is hash for the same data with 0x01 appended for entropy
+	// h3, h4 = hash.Write(data).Write([]byte{1}).Sum128()
+	k1, k2 = 0, 0
+	h1, h2 = _h1, _h2      // restore state
+	clen++                 // add entropy byte to total hash data length
+	switch len(data) + 1 { // process entropy byte *only*, no fallthrough - unless it's now a full block
+	case 16: // == entire block
+		k1 = uint64(data[0]) | uint64(data[1])<<8 | uint64(data[2])<<16 | uint64(data[3])<<24 | uint64(data[4])<<32 | uint64(data[5])<<40 | uint64(data[6])<<48 | uint64(data[7])<<56
+		k2 = uint64(data[8]) | uint64(data[9])<<8 | uint64(data[10])<<16 | uint64(data[11])<<24 | uint64(data[12])<<32 | uint64(data[13])<<40 | uint64(data[14])<<48 | entropy<<56
+
+		k1 *= c1_128
+		k1 = bits.RotateLeft64(k1, 31)
+		k1 *= c2_128
+		h1 ^= k1
+
+		h1 = bits.RotateLeft64(h1, 27)
+		h1 += h2
+		h1 = h1*5 + 0x52dce729
+
+		k2 *= c2_128
+		k2 = bits.RotateLeft64(k2, 33)
+		k2 *= c1_128
+		h2 ^= k2
+
+		h2 = bits.RotateLeft64(h2, 31)
+		h2 += h1
+		h2 = h2*5 + 0x38495ab5
+	case 15:
+		k2 ^= entropy << 48
+	case 14:
+		k2 ^= entropy << 40
+	case 13:
+		k2 ^= entropy << 32
+	case 12:
+		k2 ^= entropy << 24
+	case 11:
+		k2 ^= entropy << 16
+	case 10:
+		k2 ^= entropy << 8
+	case 9:
+		k2 ^= entropy << 0
+		k2 *= c2_128
+		k2 = bits.RotateLeft64(k2, 33)
+		k2 *= c1_128
+		h2 ^= k2
+	case 8:
+		k1 ^= entropy << 56
+	case 7:
+		k1 ^= entropy << 48
+	case 6:
+		k1 ^= entropy << 40
+	case 5:
+		k1 ^= entropy << 32
+	case 4:
+		k1 ^= entropy << 24
+	case 3:
+		k1 ^= entropy << 16
+	case 2:
+		k1 ^= entropy << 8
+	case 1:
+		k1 ^= entropy << 0
+		k1 *= c1_128
+		k1 = bits.RotateLeft64(k1, 31)
+		k1 *= c2_128
+		h1 ^= k1
+	}
+
+	switch len(data) {
+	case 15: // nothing, entire block processed
+	case 14:
+		k2 ^= uint64(data[13]) << 40
+		fallthrough
+	case 13:
+		k2 ^= uint64(data[12]) << 32
+		fallthrough
+	case 12:
+		k2 ^= uint64(data[11]) << 24
+		fallthrough
+	case 11:
+		k2 ^= uint64(data[10]) << 16
+		fallthrough
+	case 10:
+		k2 ^= uint64(data[9]) << 8
+		fallthrough
+	case 9:
+		k2 ^= uint64(data[8]) << 0
+
+		k2 *= c2_128
+		k2 = bits.RotateLeft64(k2, 33)
+		k2 *= c1_128
+		h2 ^= k2
+
+		fallthrough
+
+	case 8:
+		k1 ^= uint64(data[7]) << 56
+		fallthrough
+	case 7:
+		k1 ^= uint64(data[6]) << 48
+		fallthrough
+	case 6:
+		k1 ^= uint64(data[5]) << 40
+		fallthrough
+	case 5:
+		k1 ^= uint64(data[4]) << 32
+		fallthrough
+	case 4:
+		k1 ^= uint64(data[3]) << 24
+		fallthrough
+	case 3:
+		k1 ^= uint64(data[2]) << 16
+		fallthrough
+	case 2:
+		k1 ^= uint64(data[1]) << 8
+		fallthrough
+	case 1:
+		k1 ^= uint64(data[0]) << 0
+		k1 *= c1_128
+		k1 = bits.RotateLeft64(k1, 31)
+		k1 *= c2_128
+		h1 ^= k1
+	}
+
+	h1 ^= uint64(clen)
+	h2 ^= uint64(clen)
+
+	h1 += h2
+	h2 += h1
+
+	h1 = fmix64(h1)
+	h2 = fmix64(h2)
+
+	h1 += h2
+	h2 += h1
+	res[2], res[3] = h1, h2
+	return res
+}
+
+func fmix64(k uint64) uint64 {
+	k ^= k >> 33
+	k *= 0xff51afd7ed558ccd
+	k ^= k >> 33
+	k *= 0xc4ceb9fe1a85ec53
+	k ^= k >> 33
+	return k
+}

--- a/murmur.go
+++ b/murmur.go
@@ -24,8 +24,9 @@ func sum128WithEntropy(data []byte) [4]uint64 {
 		h1, h2 uint64
 		res    [4]uint64
 	)
+	// Calculate 1st set of hashes - twmb/murmur3 Sum128() of payload
 	clen := len(data)
-	for len(data) >= 16 {
+	for len(data) >= 16 { // bmix() step
 		// yes, this is faster than using binary.LittleEndian.Uint64
 		k1 := uint64(data[0]) | uint64(data[1])<<8 | uint64(data[2])<<16 | uint64(data[3])<<24 | uint64(data[4])<<32 | uint64(data[5])<<40 | uint64(data[6])<<48 | uint64(data[7])<<56
 		k2 := uint64(data[8]) | uint64(data[9])<<8 | uint64(data[10])<<16 | uint64(data[11])<<24 | uint64(data[12])<<32 | uint64(data[13])<<40 | uint64(data[14])<<48 | uint64(data[15])<<56
@@ -51,7 +52,11 @@ func sum128WithEntropy(data []byte) [4]uint64 {
 		h2 = h2*5 + 0x38495ab5
 	}
 
-	var _h1, _h2 = h1, h2 // save state after mixing, before final processing
+	// The following line diverges from twmb/murmur3.Sum128() in a cruicial way:
+	// - for the 2nd hash set for Bloom filter, we need to save seed state to recalculate the hash
+	//   were the *data* was exactly the same, just with the last *byte* being equal to `entropy`
+	var _h1, _h2 = h1, h2
+	// end of change from twmb/murmur3
 	var k1, k2 uint64
 	switch len(data) {
 	case 15:
@@ -122,16 +127,27 @@ func sum128WithEntropy(data []byte) [4]uint64 {
 
 	h1 += h2
 	h2 += h1
+	// End of original twmb/murmur3.Sum128
+	// Save this hash, as it's equivalent of h1, h2 = hash.Write(data).Sum128()
+	res[0], res[1] = h1, h2
 
-	res[0], res[1] = h1, h2 // done with 1st hash
-	// the last 128 bytes is hash for the same data with 0x01 appended for entropy
-	// h3, h4 = hash.Write(data).Write([]byte{1}).Sum128()
+	// Now, reset state back to before the tail calculation.
+	// The state is such that all but up to final 15 bytes have been processed, as murmur3 works
+	// on 128 bit / 16 byte chunks for all but the final mixing.
+	// last byte of the array, and apply the Sum128() logic accordingly.
 	k1, k2 = 0, 0
-	h1, h2 = _h1, _h2      // restore state
-	clen++                 // add entropy byte to total hash data length
-	switch len(data) + 1 { // process entropy byte *only*, no fallthrough - unless it's now a full block
-	case 16: // == entire block
+	h1, h2 = _h1, _h2 // restore state to before final mixing
+	clen++            // total hash data length now includes entropy
+	// Fist, process entropy byte *only*. No fallthrough.
+	// However, if we are really lucky and remainder was 15 bytes, with entropy byte it is now a full block.
+	// In that case, just apply bmix() again, with the modified payload and directly go to hash finalization.
+	rlen := len(data)
+
+	// Check if we're lucky, and have to just perform bmix() of the final chunk
+	if rlen == 15 {
 		k1 = uint64(data[0]) | uint64(data[1])<<8 | uint64(data[2])<<16 | uint64(data[3])<<24 | uint64(data[4])<<32 | uint64(data[5])<<40 | uint64(data[6])<<48 | uint64(data[7])<<56
+		// Note: this is different from original bmix() - we don't mutate `data`,
+		// so we reuse the entire 15 byte slice of the original remainder and treat the last byte as equal to `entropy`
 		k2 = uint64(data[8]) | uint64(data[9])<<8 | uint64(data[10])<<16 | uint64(data[11])<<24 | uint64(data[12])<<32 | uint64(data[13])<<40 | uint64(data[14])<<48 | entropy<<56
 
 		k1 *= c1_128
@@ -151,6 +167,13 @@ func sum128WithEntropy(data []byte) [4]uint64 {
 		h2 = bits.RotateLeft64(h2, 31)
 		h2 += h1
 		h2 = h2*5 + 0x38495ab5
+		// No further processing needed, skip the next state
+		goto Finalize
+	}
+
+	// Process entropy byte - note, **no fallthrough**, because
+	// how we process it depends on how long the payload is
+	switch rlen + 1 {
 	case 15:
 		k2 ^= entropy << 48
 	case 14:
@@ -184,15 +207,17 @@ func sum128WithEntropy(data []byte) [4]uint64 {
 	case 2:
 		k1 ^= entropy << 8
 	case 1:
+		// Case where entropy byte is the actual tail (payload length is a multiple of 16 bytes)
 		k1 ^= entropy << 0
 		k1 *= c1_128
 		k1 = bits.RotateLeft64(k1, 31)
 		k1 *= c2_128
 		h1 ^= k1
+		// Nothing else to do but finalize the hash
+		goto Finalize
 	}
 
-	switch len(data) {
-	case 15: // nothing, entire block processed
+	switch rlen {
 	case 14:
 		k2 ^= uint64(data[13]) << 40
 		fallthrough
@@ -247,6 +272,7 @@ func sum128WithEntropy(data []byte) [4]uint64 {
 		h1 ^= k1
 	}
 
+Finalize:
 	h1 ^= uint64(clen)
 	h2 ^= uint64(clen)
 
@@ -258,6 +284,8 @@ func sum128WithEntropy(data []byte) [4]uint64 {
 
 	h1 += h2
 	h2 += h1
+
+	// Save 2nd hash, twmb/murmur3.Sum128(data + '\0x01') (byte of entropy)
 	res[2], res[3] = h1, h2
 	return res
 }

--- a/murmur_test.go
+++ b/murmur_test.go
@@ -1,0 +1,78 @@
+package bloom
+
+import (
+	"testing"
+
+	"github.com/leanovate/gopter"
+	"github.com/leanovate/gopter/gen"
+	"github.com/leanovate/gopter/prop"
+	stackmurmur3 "github.com/m3db/stackmurmur3"
+	"github.com/stretchr/testify/assert"
+	twmbmurmur3 "github.com/twmb/murmur3"
+)
+
+// previous implementation using a fork of github.com/spaolacci/murmur3
+func stackConcurrentBloomFilterHashes(data []byte) [4]uint64 {
+	var hash stackmurmur3.Digest128
+	hash = hash.Write(data)
+	h1, h2 := hash.Sum128()
+	hash = hash.Write([]byte{1}) // Add entropy
+	h3, h4 := hash.Sum128()
+	return [4]uint64{h1, h2, h3, h4}
+}
+
+func TestMurmurSum128(t *testing.T) {
+	properties := gopter.NewProperties(newGopterTestParameters())
+	properties.Property("twmb digest matches spaolacci", prop.ForAll(
+		func(v []byte) bool {
+			twmbH1, twmbH2 := twmbmurmur3.Sum128(v)
+			var hash stackmurmur3.Digest128
+			hash = hash.Write(v)
+			spH1, spH2 := hash.Sum128()
+			return spH1 == twmbH1 && spH2 == twmbH2
+		},
+		newByteGen(),
+	))
+
+	properties.TestingRun(t)
+}
+
+func TestBloomFilterHashes(t *testing.T) {
+	properties := gopter.NewProperties(newGopterTestParameters())
+	properties.Property("sum128WithEntropy matches stackmurmur3", prop.ForAll(
+		func(v []byte) bool {
+			var twmbH, spH [4]uint64
+			twmbH = sum128WithEntropy(v)
+			spH = stackConcurrentBloomFilterHashes(v)
+			return assert.EqualValues(t, spH, twmbH)
+		},
+		newByteGen(),
+	))
+
+	properties.TestingRun(t)
+}
+
+func newGopterTestParameters() *gopter.TestParameters {
+	params := gopter.DefaultTestParameters()
+	params.MinSuccessfulTests = 100000
+
+	return params
+}
+
+// newByteGen returns a gopter generator for an []byte. All bytes (not just valid UTF-8) are generated.
+func newByteGen() gopter.Gen {
+	// uint8 == byte; therefore, derive []byte generator from []uint8 generator.
+	return gopter.DeriveGen(func(v []uint8) []byte {
+		out := make([]byte, len(v))
+		for i, val := range v {
+			out[i] = val
+		}
+		return out
+	}, func(v []byte) []uint8 {
+		out := make([]byte, len(v))
+		for i, val := range v {
+			out[i] = val
+		}
+		return out
+	}, gen.SliceOf(gen.UInt8()))
+}

--- a/murmur_test.go
+++ b/murmur_test.go
@@ -1,11 +1,15 @@
 package bloom
 
 import (
+	"crypto/rand"
+	"io"
 	"testing"
+	"unsafe"
 
 	"github.com/leanovate/gopter"
 	"github.com/leanovate/gopter/gen"
 	"github.com/leanovate/gopter/prop"
+	"github.com/m3db/bloom/testdata"
 	stackmurmur3 "github.com/m3db/stackmurmur3"
 	"github.com/stretchr/testify/assert"
 	twmbmurmur3 "github.com/twmb/murmur3"
@@ -38,7 +42,7 @@ func TestBloomFilterHashesReferenceVsNew(t *testing.T) {
 			func(v []byte) bool {
 				var twmbH, spH [4]uint64
 				twmbH = sum128WithEntropy(v)
-				spH = concurrentBloomFilterHashes(v)
+				spH = concurrentBloomFilterHashesReference(v)
 				return assert.EqualValues(t, spH, twmbH)
 			},
 			newByteGen(),
@@ -46,6 +50,96 @@ func TestBloomFilterHashesReferenceVsNew(t *testing.T) {
 	)
 
 	properties.TestingRun(t)
+}
+
+func TestBloomFilterHashesTwmbVsNew(t *testing.T) {
+	properties := gopter.NewProperties(newGopterTestParameters())
+	properties.Property("sum128WithEntropy matches reference stackmurmur3-based implementation",
+		prop.ForAll(
+			func(v []byte) bool {
+				var twmbH, spH [4]uint64
+				twmbH = sum128WithEntropy(v)
+				spH = concurrentBloomFilterHashesTwmb(v)
+				return assert.EqualValues(t, spH, twmbH)
+			},
+			newByteGen(),
+		),
+	)
+
+	properties.TestingRun(t)
+}
+func TestBloomFilterHashesTwmbTestSuite(t *testing.T) {
+	for _, test := range []struct {
+		h64_1 uint64
+		h64_2 uint64
+		s     string
+	}{
+		// test suite from "github.com/twmb/murmur3"
+		{0x0000000000000000, 0x0000000000000000, ""},
+		{0xcbd8a7b341bd9b02, 0x5b1e906a48ae1d19, "hello"},
+		{0x342fac623a5ebc8e, 0x4cdcbc079642414d, "hello, world"},
+		{0xb89e5988b737affc, 0x664fc2950231b2cb, "19 Jan 2038 at 3:14:07 AM"},
+		{0xcd99481f9ee902c9, 0x695da1a38987b6e7, "The quick brown fox jumps over the lazy dog."},
+	} {
+		refh1, refh2 := twmbmurmur3.StringSum128(test.s)
+		hash := sum128WithEntropy([]byte(test.s))
+		assert.EqualValues(t, refh1, hash[0])
+		assert.EqualValues(t, refh2, hash[1])
+	}
+}
+
+// Test suite function from github.com/twmb/murmur3
+// go1.14 showed that doing *(*uint32)(unsafe.Pointer(&data[i*4])) was unsafe
+// due to alignment issues; this test ensures that we will always catch that.
+func TestUnaligned(t *testing.T) {
+	in1 := []byte("abcdefghijklmnopqrstuvwxyz")
+	in2 := []byte("_abcdefghijklmnopqrstuvwxyz")
+	{
+		hash1 := sum128WithEntropy(in1)
+		hash2 := sum128WithEntropy(in2[1:])
+		sum1l, sum1r := hash1[0], hash1[1]
+		sum2l, sum2r := hash2[0], hash2[1]
+
+		if sum1l != sum2l {
+			t.Errorf("%s: got sum1l %v sum2l %v unexpectedly not equal", "Sum128 left", sum1l, sum2l)
+		}
+		if sum1r != sum2r {
+			t.Errorf("%s: got sum1r %v sum2r %v unexpectedly not equal", "Sum128 right", sum1r, sum2r)
+		}
+	}
+}
+
+// Test suite function from github.com/twmb/murmur3
+// TestBoundaries forces every block/tail path to be exercised for Sum32 and Sum128.
+func TestBoundaries(t *testing.T) {
+	const maxCheck = 17
+	var (
+		isLittleEndian = func() bool {
+			i := uint16(1)
+			return (*(*[2]byte)(unsafe.Pointer(&i)))[0] == 1
+		}()
+		data [maxCheck]byte
+	)
+	for i := 0; !t.Failed() && i < 20; i++ {
+		// Check all zeros the first iteration.
+		for size := 0; size <= maxCheck; size++ {
+			test := data[:size]
+			hash := sum128WithEntropy(test)
+			g128h1, g128h2 := hash[0], hash[1]
+			c128h1, c128h2 := g128h1, g128h2
+			if isLittleEndian {
+				c128h1, c128h2 = testdata.SeedSum128(0, test)
+			}
+			if g128h1 != c128h1 {
+				t.Errorf("size #%d: in: %x, g128h1 (%d) != c128h1 (%d); attempt #%d", size, test, g128h1, c128h1, i)
+			}
+			if g128h2 != c128h2 {
+				t.Errorf("size #%d: in: %x, g128h2 (%d) != c128h2 (%d); attempt #%d", size, test, g128h2, c128h2, i)
+			}
+		}
+		// Randomize the data for all subsequent tests.
+		io.ReadFull(rand.Reader, data[:])
+	}
 }
 
 func BenchmarkBloomFilterHash(b *testing.B) {
@@ -57,16 +151,26 @@ func BenchmarkBloomFilterHash(b *testing.B) {
 func BenchmarkBloomFilterHashReference(b *testing.B) {
 	buf := []byte(_benchStr)
 	for i := 0; i < b.N; i++ {
-		_ = concurrentBloomFilterHashes(buf)
+		_ = concurrentBloomFilterHashesReference(buf)
 	}
 }
 
 // reference implementation using a fork of github.com/spaolacci/murmur3
-func concurrentBloomFilterHashes(data []byte) [4]uint64 {
+func concurrentBloomFilterHashesReference(data []byte) [4]uint64 {
 	var hash stackmurmur3.Digest128
 	hash = hash.Write(data)
 	h1, h2 := hash.Sum128()
 	hash = hash.Write(_entropy) // Add entropy
+	h3, h4 := hash.Sum128()
+	return [4]uint64{h1, h2, h3, h4}
+}
+
+// reference implementation using a fork of github.com/twmb/murmur3
+func concurrentBloomFilterHashesTwmb(data []byte) [4]uint64 {
+	var hash = twmbmurmur3.New128()
+	hash.Write(data)
+	h1, h2 := hash.Sum128()
+	hash.Write(_entropy) // Add entropy
 	h3, h4 := hash.Sum128()
 	return [4]uint64{h1, h2, h3, h4}
 }

--- a/murmur_test.go
+++ b/murmur_test.go
@@ -148,8 +148,41 @@ func BenchmarkBloomFilterHash(b *testing.B) {
 		_ = sum128WithEntropy(buf)
 	}
 }
+
+func BenchmarkBloomFilterHash15(b *testing.B) {
+	//  payload is not a multiple of 16 bytes, tail is 15 bytes
+	buf := []byte(_benchStr + _benchStr)[:127]
+	for i := 0; i < b.N; i++ {
+		_ = sum128WithEntropy(buf)
+	}
+}
+
+func BenchmarkBloomFilterHash16(b *testing.B) {
+	// payload is a multiple of 16 bytes
+	buf := []byte(_benchStr + _benchStr)[:128]
+	for i := 0; i < b.N; i++ {
+		_ = sum128WithEntropy(buf)
+	}
+}
+
 func BenchmarkBloomFilterHashReference(b *testing.B) {
 	buf := []byte(_benchStr)
+	for i := 0; i < b.N; i++ {
+		_ = concurrentBloomFilterHashesReference(buf)
+	}
+}
+
+func BenchmarkBloomFilterHashReference15(b *testing.B) {
+	//  payload is not a multiple of 16 bytes, tail is 15 bytes
+	buf := []byte(_benchStr + _benchStr)[:127]
+	for i := 0; i < b.N; i++ {
+		_ = concurrentBloomFilterHashesReference(buf)
+	}
+}
+
+func BenchmarkBloomFilterHashReference16(b *testing.B) {
+	// payload is a multiple of 16 bytes
+	buf := []byte(_benchStr + _benchStr)[:128]
 	for i := 0; i < b.N; i++ {
 		_ = concurrentBloomFilterHashesReference(buf)
 	}

--- a/murmur_test.go
+++ b/murmur_test.go
@@ -31,17 +31,19 @@ func TestMurmurTwmbVsStackSum128(t *testing.T) {
 	properties.TestingRun(t)
 }
 
-func TestBloomFilterHashesOldVsNew(t *testing.T) {
+func TestBloomFilterHashesReferenceVsNew(t *testing.T) {
 	properties := gopter.NewProperties(newGopterTestParameters())
-	properties.Property("sum128WithEntropy matches stackmurmur3", prop.ForAll(
-		func(v []byte) bool {
-			var twmbH, spH [4]uint64
-			twmbH = sum128WithEntropy(v)
-			spH = concurrentBloomFilterHashes(v)
-			return assert.EqualValues(t, spH, twmbH)
-		},
-		newByteGen(),
-	))
+	properties.Property("sum128WithEntropy matches reference stackmurmur3-based implementation",
+		prop.ForAll(
+			func(v []byte) bool {
+				var twmbH, spH [4]uint64
+				twmbH = sum128WithEntropy(v)
+				spH = concurrentBloomFilterHashes(v)
+				return assert.EqualValues(t, spH, twmbH)
+			},
+			newByteGen(),
+		),
+	)
 
 	properties.TestingRun(t)
 }
@@ -52,14 +54,14 @@ func BenchmarkBloomFilterHash(b *testing.B) {
 		_ = sum128WithEntropy(buf)
 	}
 }
-func BenchmarkBloomFilterHashOld(b *testing.B) {
+func BenchmarkBloomFilterHashReference(b *testing.B) {
 	buf := []byte(_benchStr)
 	for i := 0; i < b.N; i++ {
 		_ = concurrentBloomFilterHashes(buf)
 	}
 }
 
-// previous implementation using a fork of github.com/spaolacci/murmur3
+// reference implementation using a fork of github.com/spaolacci/murmur3
 func concurrentBloomFilterHashes(data []byte) [4]uint64 {
 	var hash stackmurmur3.Digest128
 	hash = hash.Write(data)

--- a/murmur_test.go
+++ b/murmur_test.go
@@ -15,7 +15,7 @@ const _benchStr = `"The quick brown fox jumps over the lazy dog" is an English-l
 
 var _entropy = []byte{1}
 
-func TestMurmurSum128(t *testing.T) {
+func TestMurmurTwmbVsStackSum128(t *testing.T) {
 	properties := gopter.NewProperties(newGopterTestParameters())
 	properties.Property("twmb digest matches spaolacci", prop.ForAll(
 		func(v []byte) bool {
@@ -31,7 +31,7 @@ func TestMurmurSum128(t *testing.T) {
 	properties.TestingRun(t)
 }
 
-func TestBloomFilterHashes(t *testing.T) {
+func TestBloomFilterHashesOldVsNew(t *testing.T) {
 	properties := gopter.NewProperties(newGopterTestParameters())
 	properties.Property("sum128WithEntropy matches stackmurmur3", prop.ForAll(
 		func(v []byte) bool {

--- a/testdata/MurmurHash3.cpp
+++ b/testdata/MurmurHash3.cpp
@@ -1,0 +1,335 @@
+//-----------------------------------------------------------------------------
+// MurmurHash3 was written by Austin Appleby, and is placed in the public
+// domain. The author hereby disclaims copyright to this source code.
+
+// Note - The x86 and x64 versions do _not_ produce the same results, as the
+// algorithms are optimized for their respective platforms. You can still
+// compile and run any of them on any platform, but your performance with the
+// non-native version will be less than optimal.
+
+#include "MurmurHash3.h"
+
+//-----------------------------------------------------------------------------
+// Platform-specific functions and macros
+
+// Microsoft Visual Studio
+
+#if defined(_MSC_VER)
+
+#define FORCE_INLINE	__forceinline
+
+#include <stdlib.h>
+
+#define ROTL32(x,y)	_rotl(x,y)
+#define ROTL64(x,y)	_rotl64(x,y)
+
+#define BIG_CONSTANT(x) (x)
+
+// Other compilers
+
+#else	// defined(_MSC_VER)
+
+#define	FORCE_INLINE inline __attribute__((always_inline))
+
+inline uint32_t rotl32 ( uint32_t x, int8_t r )
+{
+  return (x << r) | (x >> (32 - r));
+}
+
+inline uint64_t rotl64 ( uint64_t x, int8_t r )
+{
+  return (x << r) | (x >> (64 - r));
+}
+
+#define	ROTL32(x,y)	rotl32(x,y)
+#define ROTL64(x,y)	rotl64(x,y)
+
+#define BIG_CONSTANT(x) (x##LLU)
+
+#endif // !defined(_MSC_VER)
+
+//-----------------------------------------------------------------------------
+// Block read - if your platform needs to do endian-swapping or can only
+// handle aligned reads, do the conversion here
+
+FORCE_INLINE uint32_t getblock32 ( const uint32_t * p, int i )
+{
+  return p[i];
+}
+
+FORCE_INLINE uint64_t getblock64 ( const uint64_t * p, int i )
+{
+  return p[i];
+}
+
+//-----------------------------------------------------------------------------
+// Finalization mix - force all bits of a hash block to avalanche
+
+FORCE_INLINE uint32_t fmix32 ( uint32_t h )
+{
+  h ^= h >> 16;
+  h *= 0x85ebca6b;
+  h ^= h >> 13;
+  h *= 0xc2b2ae35;
+  h ^= h >> 16;
+
+  return h;
+}
+
+//----------
+
+FORCE_INLINE uint64_t fmix64 ( uint64_t k )
+{
+  k ^= k >> 33;
+  k *= BIG_CONSTANT(0xff51afd7ed558ccd);
+  k ^= k >> 33;
+  k *= BIG_CONSTANT(0xc4ceb9fe1a85ec53);
+  k ^= k >> 33;
+
+  return k;
+}
+
+//-----------------------------------------------------------------------------
+
+void MurmurHash3_x86_32 ( const void * key, int len,
+                          uint32_t seed, void * out )
+{
+  const uint8_t * data = (const uint8_t*)key;
+  const int nblocks = len / 4;
+
+  uint32_t h1 = seed;
+
+  const uint32_t c1 = 0xcc9e2d51;
+  const uint32_t c2 = 0x1b873593;
+
+  //----------
+  // body
+
+  const uint32_t * blocks = (const uint32_t *)(data + nblocks*4);
+
+  for(int i = -nblocks; i; i++)
+  {
+    uint32_t k1 = getblock32(blocks,i);
+
+    k1 *= c1;
+    k1 = ROTL32(k1,15);
+    k1 *= c2;
+    
+    h1 ^= k1;
+    h1 = ROTL32(h1,13); 
+    h1 = h1*5+0xe6546b64;
+  }
+
+  //----------
+  // tail
+
+  const uint8_t * tail = (const uint8_t*)(data + nblocks*4);
+
+  uint32_t k1 = 0;
+
+  switch(len & 3)
+  {
+  case 3: k1 ^= tail[2] << 16;
+  case 2: k1 ^= tail[1] << 8;
+  case 1: k1 ^= tail[0];
+          k1 *= c1; k1 = ROTL32(k1,15); k1 *= c2; h1 ^= k1;
+  };
+
+  //----------
+  // finalization
+
+  h1 ^= len;
+
+  h1 = fmix32(h1);
+
+  *(uint32_t*)out = h1;
+} 
+
+//-----------------------------------------------------------------------------
+
+void MurmurHash3_x86_128 ( const void * key, const int len,
+                           uint32_t seed, void * out )
+{
+  const uint8_t * data = (const uint8_t*)key;
+  const int nblocks = len / 16;
+
+  uint32_t h1 = seed;
+  uint32_t h2 = seed;
+  uint32_t h3 = seed;
+  uint32_t h4 = seed;
+
+  const uint32_t c1 = 0x239b961b; 
+  const uint32_t c2 = 0xab0e9789;
+  const uint32_t c3 = 0x38b34ae5; 
+  const uint32_t c4 = 0xa1e38b93;
+
+  //----------
+  // body
+
+  const uint32_t * blocks = (const uint32_t *)(data + nblocks*16);
+
+  for(int i = -nblocks; i; i++)
+  {
+    uint32_t k1 = getblock32(blocks,i*4+0);
+    uint32_t k2 = getblock32(blocks,i*4+1);
+    uint32_t k3 = getblock32(blocks,i*4+2);
+    uint32_t k4 = getblock32(blocks,i*4+3);
+
+    k1 *= c1; k1  = ROTL32(k1,15); k1 *= c2; h1 ^= k1;
+
+    h1 = ROTL32(h1,19); h1 += h2; h1 = h1*5+0x561ccd1b;
+
+    k2 *= c2; k2  = ROTL32(k2,16); k2 *= c3; h2 ^= k2;
+
+    h2 = ROTL32(h2,17); h2 += h3; h2 = h2*5+0x0bcaa747;
+
+    k3 *= c3; k3  = ROTL32(k3,17); k3 *= c4; h3 ^= k3;
+
+    h3 = ROTL32(h3,15); h3 += h4; h3 = h3*5+0x96cd1c35;
+
+    k4 *= c4; k4  = ROTL32(k4,18); k4 *= c1; h4 ^= k4;
+
+    h4 = ROTL32(h4,13); h4 += h1; h4 = h4*5+0x32ac3b17;
+  }
+
+  //----------
+  // tail
+
+  const uint8_t * tail = (const uint8_t*)(data + nblocks*16);
+
+  uint32_t k1 = 0;
+  uint32_t k2 = 0;
+  uint32_t k3 = 0;
+  uint32_t k4 = 0;
+
+  switch(len & 15)
+  {
+  case 15: k4 ^= tail[14] << 16;
+  case 14: k4 ^= tail[13] << 8;
+  case 13: k4 ^= tail[12] << 0;
+           k4 *= c4; k4  = ROTL32(k4,18); k4 *= c1; h4 ^= k4;
+
+  case 12: k3 ^= tail[11] << 24;
+  case 11: k3 ^= tail[10] << 16;
+  case 10: k3 ^= tail[ 9] << 8;
+  case  9: k3 ^= tail[ 8] << 0;
+           k3 *= c3; k3  = ROTL32(k3,17); k3 *= c4; h3 ^= k3;
+
+  case  8: k2 ^= tail[ 7] << 24;
+  case  7: k2 ^= tail[ 6] << 16;
+  case  6: k2 ^= tail[ 5] << 8;
+  case  5: k2 ^= tail[ 4] << 0;
+           k2 *= c2; k2  = ROTL32(k2,16); k2 *= c3; h2 ^= k2;
+
+  case  4: k1 ^= tail[ 3] << 24;
+  case  3: k1 ^= tail[ 2] << 16;
+  case  2: k1 ^= tail[ 1] << 8;
+  case  1: k1 ^= tail[ 0] << 0;
+           k1 *= c1; k1  = ROTL32(k1,15); k1 *= c2; h1 ^= k1;
+  };
+
+  //----------
+  // finalization
+
+  h1 ^= len; h2 ^= len; h3 ^= len; h4 ^= len;
+
+  h1 += h2; h1 += h3; h1 += h4;
+  h2 += h1; h3 += h1; h4 += h1;
+
+  h1 = fmix32(h1);
+  h2 = fmix32(h2);
+  h3 = fmix32(h3);
+  h4 = fmix32(h4);
+
+  h1 += h2; h1 += h3; h1 += h4;
+  h2 += h1; h3 += h1; h4 += h1;
+
+  ((uint32_t*)out)[0] = h1;
+  ((uint32_t*)out)[1] = h2;
+  ((uint32_t*)out)[2] = h3;
+  ((uint32_t*)out)[3] = h4;
+}
+
+//-----------------------------------------------------------------------------
+
+void MurmurHash3_x64_128 ( const void * key, const int len,
+                           const uint32_t seed, void * out )
+{
+  const uint8_t * data = (const uint8_t*)key;
+  const int nblocks = len / 16;
+
+  uint64_t h1 = seed;
+  uint64_t h2 = seed;
+
+  const uint64_t c1 = BIG_CONSTANT(0x87c37b91114253d5);
+  const uint64_t c2 = BIG_CONSTANT(0x4cf5ad432745937f);
+
+  //----------
+  // body
+
+  const uint64_t * blocks = (const uint64_t *)(data);
+
+  for(int i = 0; i < nblocks; i++)
+  {
+    uint64_t k1 = getblock64(blocks,i*2+0);
+    uint64_t k2 = getblock64(blocks,i*2+1);
+
+    k1 *= c1; k1  = ROTL64(k1,31); k1 *= c2; h1 ^= k1;
+
+    h1 = ROTL64(h1,27); h1 += h2; h1 = h1*5+0x52dce729;
+
+    k2 *= c2; k2  = ROTL64(k2,33); k2 *= c1; h2 ^= k2;
+
+    h2 = ROTL64(h2,31); h2 += h1; h2 = h2*5+0x38495ab5;
+  }
+
+  //----------
+  // tail
+
+  const uint8_t * tail = (const uint8_t*)(data + nblocks*16);
+
+  uint64_t k1 = 0;
+  uint64_t k2 = 0;
+
+  switch(len & 15)
+  {
+  case 15: k2 ^= ((uint64_t)tail[14]) << 48;
+  case 14: k2 ^= ((uint64_t)tail[13]) << 40;
+  case 13: k2 ^= ((uint64_t)tail[12]) << 32;
+  case 12: k2 ^= ((uint64_t)tail[11]) << 24;
+  case 11: k2 ^= ((uint64_t)tail[10]) << 16;
+  case 10: k2 ^= ((uint64_t)tail[ 9]) << 8;
+  case  9: k2 ^= ((uint64_t)tail[ 8]) << 0;
+           k2 *= c2; k2  = ROTL64(k2,33); k2 *= c1; h2 ^= k2;
+
+  case  8: k1 ^= ((uint64_t)tail[ 7]) << 56;
+  case  7: k1 ^= ((uint64_t)tail[ 6]) << 48;
+  case  6: k1 ^= ((uint64_t)tail[ 5]) << 40;
+  case  5: k1 ^= ((uint64_t)tail[ 4]) << 32;
+  case  4: k1 ^= ((uint64_t)tail[ 3]) << 24;
+  case  3: k1 ^= ((uint64_t)tail[ 2]) << 16;
+  case  2: k1 ^= ((uint64_t)tail[ 1]) << 8;
+  case  1: k1 ^= ((uint64_t)tail[ 0]) << 0;
+           k1 *= c1; k1  = ROTL64(k1,31); k1 *= c2; h1 ^= k1;
+  };
+
+  //----------
+  // finalization
+
+  h1 ^= len; h2 ^= len;
+
+  h1 += h2;
+  h2 += h1;
+
+  h1 = fmix64(h1);
+  h2 = fmix64(h2);
+
+  h1 += h2;
+  h2 += h1;
+
+  ((uint64_t*)out)[0] = h1;
+  ((uint64_t*)out)[1] = h2;
+}
+
+//-----------------------------------------------------------------------------
+

--- a/testdata/MurmurHash3.h
+++ b/testdata/MurmurHash3.h
@@ -1,0 +1,37 @@
+//-----------------------------------------------------------------------------
+// MurmurHash3 was written by Austin Appleby, and is placed in the public
+// domain. The author hereby disclaims copyright to this source code.
+
+#ifndef _MURMURHASH3_H_
+#define _MURMURHASH3_H_
+
+//-----------------------------------------------------------------------------
+// Platform-specific functions and macros
+
+// Microsoft Visual Studio
+
+#if defined(_MSC_VER) && (_MSC_VER < 1600)
+
+typedef unsigned char uint8_t;
+typedef unsigned int uint32_t;
+typedef unsigned __int64 uint64_t;
+
+// Other compilers
+
+#else	// defined(_MSC_VER)
+
+#include <stdint.h>
+
+#endif // !defined(_MSC_VER)
+
+//-----------------------------------------------------------------------------
+
+void MurmurHash3_x86_32  ( const void * key, int len, uint32_t seed, void * out );
+
+void MurmurHash3_x86_128 ( const void * key, int len, uint32_t seed, void * out );
+
+void MurmurHash3_x64_128 ( const void * key, int len, uint32_t seed, void * out );
+
+//-----------------------------------------------------------------------------
+
+#endif // _MURMURHASH3_H_

--- a/testdata/test.go
+++ b/testdata/test.go
@@ -1,0 +1,45 @@
+package testdata
+
+// #cgo CFLAGS: -std=gnu99
+// #include <stdint.h>
+// #include "MurmurHash3.cpp"
+// #include "MurmurHash3.h"
+import "C"
+
+import "unsafe"
+
+func SeedSum32(seed uint32, data []byte) uint32 {
+	var p unsafe.Pointer
+	if len(data) > 0 {
+		p = unsafe.Pointer(&data[0])
+	}
+	var out uint32
+	C.MurmurHash3_x86_32(p, C.int(len(data)), C.uint32_t(seed), unsafe.Pointer(&out))
+	return out
+}
+
+func SeedSum64(seed uint32, data []byte) uint64 {
+	var p unsafe.Pointer
+	if len(data) > 0 {
+		p = unsafe.Pointer(&data[0])
+	}
+	var out struct {
+		h1 uint64
+		h2 uint64
+	}
+	C.MurmurHash3_x64_128(p, C.int(len(data)), C.uint32_t(seed), unsafe.Pointer(&out))
+	return out.h1
+}
+
+func SeedSum128(seed uint32, data []byte) (h1, h2 uint64) {
+	var p unsafe.Pointer
+	if len(data) > 0 {
+		p = unsafe.Pointer(&data[0])
+	}
+	var out struct {
+		h1 uint64
+		h2 uint64
+	}
+	C.MurmurHash3_x64_128(p, C.int(len(data)), C.uint32_t(seed), unsafe.Pointer(&out))
+	return out.h1, out.h2
+}


### PR DESCRIPTION
Use hand-rolled hash function, identical to the existing algo using `m3db/stackmurmur3`

Code is all based on `twmb/murmur3` and is actually faster, without any use of `unsafe` or assembly for `amd64`
```
name                    old time/op    new time/op    delta
AddX10kX5-12              98.6ns ± 1%    67.4ns ± 0%  -31.66%  (p=0.000 n=10+9)
Contains1kX10kX5-12       89.0ns ± 1%    57.1ns ± 1%  -35.88%  (p=0.000 n=9+9)
Contains100kX10BX20-12     215ns ± 2%     173ns ± 1%  -19.35%  (p=0.000 n=10+10)

name                    old alloc/op   new alloc/op   delta
AddX10kX5-12               0.00B          0.00B          ~     (all equal)
Contains1kX10kX5-12        0.00B          0.00B          ~     (all equal)
Contains100kX10BX20-12     0.00B          0.00B          ~     (all equal)

name                           time/op
BloomFilterHash-12             29.2ns ± 1%
BloomFilterHash15-12           32.2ns ± 1%
BloomFilterHash16-12           25.5ns ± 1%
BloomFilterHashReference-12    65.9ns ± 0%
BloomFilterHashReference15-12  83.6ns ± 0%
BloomFilterHashReference16-12  67.7ns ± 0%
```